### PR TITLE
SLING-10263 create the sling-versionmgr system user with path system/sling

### DIFF
--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -8,13 +8,13 @@
     "configurations":{
         "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended~sling-versionmgr":{
             "user.mapping":[
-                "org.apache.sling.jcr.maintenance:sling-versionmgr=sling-versionmgr"
+                "org.apache.sling.jcr.maintenance:sling-versionmgr=[sling-versionmgr]"
             ]
         }
     },
     "repoinit:TEXT|true": [
         "create service user sling-versionmgr with path system/sling",
-        "set ACL for sling-versionmgr",
+        "set principal ACL for sling-versionmgr",
         "allow   jcr:write,jcr:nodeTypeManagement,jcr:versionManagement    on /",
         "allow   jcr:read    on /jcr:system/jcr:versionStorage",
         "end"

--- a/src/main/features/base.json
+++ b/src/main/features/base.json
@@ -13,7 +13,7 @@
         }
     },
     "repoinit:TEXT|true": [
-        "create service user sling-versionmgr",
+        "create service user sling-versionmgr with path system/sling",
         "set ACL for sling-versionmgr",
         "allow   jcr:write,jcr:nodeTypeManagement,jcr:versionManagement    on /",
         "allow   jcr:read    on /jcr:system/jcr:versionStorage",


### PR DESCRIPTION
All the system users created in the starter are created with path system/sling

For consistency, create the sling-versionmgr system user with the same path.

Also, use pre-authentication for system users to achieve the equivalent of what was done for SLING-9786