### PR TITLE
SLING-11211: updated maven dependencies && fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This project provides reference implementation of Maintenance jobs for maintaini
 
 This includes the following Maintenance jobs:
 
-- [DataStoreCleanupScheduler](src/main/java/org/apache/sling/maintenance/internal/DataStoreCleanupScheduler.java) - Run the [RepositoryManagementMBean.startDataStoreGC(true)](https://jackrabbit.apache.org/oak/docs/apidocs/org/apache/jackrabbit/oak/api/jmx/RepositoryManagementMBean.html#startDataStoreGC-boolean-) method to perform a Garbage Collection of the Data Store
-- [RevisionCleanupScheduler](src/main/java/org/apache/sling/maintenance/internal/RevisionCleanupScheduler.java) - Run the [RepositoryManagementMBean.startRevisionGC()](https://jackrabbit.apache.org/oak/docs/apidocs/org/apache/jackrabbit/oak/api/jmx/RepositoryManagementMBean.html#startRevisionGC--) method to perform a Garbage Collection of the Revision Store
-- [VersionCleanup](src/main/java/org/apache/sling/maintenance/internal/VersionCleanup.java) - Job to traverse the JCR Version Store
+- [DataStoreCleanupScheduler](src/main/java/org/apache/sling/jcr/maintenance/internal/DataStoreCleanupScheduler.java) - Run the [RepositoryManagementMBean.startDataStoreGC(true)](https://jackrabbit.apache.org/oak/docs/apidocs/org/apache/jackrabbit/oak/api/jmx/RepositoryManagementMBean.html#startDataStoreGC-boolean-) method to perform a Garbage Collection of the Data Store
+- [RevisionCleanupScheduler](src/main/java/org/apache/sling/jcr/maintenance/internal/RevisionCleanupScheduler.java) - Run the [RepositoryManagementMBean.startRevisionGC()](https://jackrabbit.apache.org/oak/docs/apidocs/org/apache/jackrabbit/oak/api/jmx/RepositoryManagementMBean.html#startRevisionGC--) method to perform a Garbage Collection of the Revision Store
+- [VersionCleanup](src/main/java/org/apache/sling/jcr/maintenance/internal/VersionCleanup.java) - Job to traverse the JCR Version Store
   and remove versions (oldest-first) exceeding a configurable limit
 
-As well as a [Health Check](src/main/java/org/apache/sling/maintenance/internal/RepositoryMaintenanceHealthCheck.java) to ensure the jobs are scheduled and have not failed.
+As well as a [Health Check](src/main/java/org/apache/sling/jcr/maintenance/internal/RepositoryMaintenanceHealthCheck.java) to ensure the jobs are scheduled and have not failed.
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>41</version>
+        <version>46</version>
         <relativePath />
     </parent>
     <artifactId>org.apache.sling.jcr.maintenance</artifactId>
@@ -31,7 +31,9 @@
     <description>Maintenance jobs for the JCR</description>
 
     <properties>
+        <sling.java.version>8</sling.java.version>
         <project.build.outputTimestamp>2021-04-15T18:14:05Z</project.build.outputTimestamp>
+        <oak.version>1.40.0</oak.version>
     </properties>
 
 
@@ -62,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>slingfeature-maven-plugin</artifactId>
-                <version>1.4.18</version>
+                <version>1.6.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <framework>
@@ -117,7 +119,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.healthcheck.api</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -129,25 +131,24 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-core</artifactId>
-            <version>1.8.8</version>
+            <version>${oak.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-jcr</artifactId>
-            <version>1.8.8</version>
+            <version>${oak.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.18.4</version>
+            <version>2.24.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>20.1.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -185,19 +186,19 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-            <version>2.6.2</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <version>2.1.10-1.16.0</version>
+            <version>3.1.2-1.40.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.28</version>
+            <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>46</version>
+        <version>47</version>
         <relativePath />
     </parent>
     <artifactId>org.apache.sling.jcr.maintenance</artifactId>
@@ -31,7 +31,6 @@
     <description>Maintenance jobs for the JCR</description>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
         <project.build.outputTimestamp>2021-04-15T18:14:05Z</project.build.outputTimestamp>
         <oak.version>1.40.0</oak.version>
     </properties>
@@ -102,6 +101,8 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <!-- Javax Dependencies -->
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
@@ -111,8 +112,6 @@
         <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
-            <version>2.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Apache Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.outputTimestamp>2021-04-15T18:14:05Z</project.build.outputTimestamp>
-        <oak.version>1.40.0</oak.version>
+        <oak.version>1.8.8</oak.version>
     </properties>
 
 
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <version>3.1.2-1.40.0</version>
+            <version>2.1.10-1.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <oak.version>1.8.8</oak.version>
     </properties>
 
-
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-maintenance.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-jcr-maintenance.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.24.0</version>
+            <version>2.18.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Updated sling parent bundle to version 46
- Updated maven dependencies for junit4
- Fixed broken links in README.md