### PR TITLE
SLING-12034 bump oak dependency for compatibility with version 1.56.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ There are two primary features made by this project include:
 - **Default** - org.apache.sling:org.apache.sling.jcr.maintenance:slingosgifeature:default:${project.version} - the bundle, service user and default configuration which keeps 5 versions and runs the jobs every night
 
 This module is part of the [Apache Sling](https://sling.apache.org) project.
+
+## Compatibility
+
+When paring the bundles in your installation, these are the version combinations that would be compatible:
+
+| Apache Sling JCR Maintenance | Apache Jackrabbit Oak |
+|---|---|
+| 1.0.2 | 1.8.8 to 1.54.0 |
+| 1.1.0 or later | 1.56.0 or later |

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.outputTimestamp>2021-04-15T18:14:05Z</project.build.outputTimestamp>
-        <oak.version>1.8.8</oak.version>
+        <oak.version>1.56.0</oak.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <relativePath />
     </parent>
     <artifactId>org.apache.sling.jcr.maintenance</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>Apache Sling JCR Maintenance</name>
     <description>Maintenance jobs for the JCR</description>
 


### PR DESCRIPTION
In order for sling to work with the latest release of oak, the oak dependencies must be bumped to 1.56.0 or later.

The oak 1.56.0 release completed the removal of the dependency on the old guava library which required a bump of the major version of some exported packages whose public api has changed.  The imports of those changed packages must be bumped to the new major version number in order for the bundles to resolve properly in the runtime.