### PR TITLE
SLING-12035: Using a permissive version range for org.apache.jackrabbit.oak.commons.jmx to enable update to latest Oak version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,19 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd>
+                                Import-Package: org.apache.jackrabbit.oak.commons.jmx;version="[0.0,3)",*
+                            </bnd>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Using a permissive version range for org.apache.jackrabbit.oak.commons.jmx to enable update to latest Oak version

Tested by:

 -  building snapshot of this bundle
 - applying the changes here: https://github.com/apache/sling-org-apache-sling-starter/pull/221/files and updating to use this bundle's snapshot version to starter
 - Running `mvn clean install` and verifying it failed with a message about the version range for `org.apache.jackrabbit.oak.commons.jmx`
 - Applying the change in this PR
 -  building snapshot of this bundle
 - Running `mvn clean install` and verifying that the error message for this bundle no longer appeared